### PR TITLE
Create new placeholder fields for model instances with other placeholders

### DIFF
--- a/fluent_contents/admin/genericextensions.py
+++ b/fluent_contents/admin/genericextensions.py
@@ -72,7 +72,7 @@ class BaseInitialGenericInlineFormSet(BaseGenericInlineFormSet):
 
             return True
 
-        return filter(initial_not_in_queryset, self._initial)
+        return list(filter(initial_not_in_queryset, self._initial))
 
     def __get_form_instance(self, i):
         instance = None


### PR DESCRIPTION
The current code in `_construct_form` uses either `self.get_queryset()[i]` or `self._initial[i]` to create an instance to pass to the form its creating. This works if the PlaceholderField is on a model that's being added (no placeholder rows in the database) or a model that exists and has placeholder rows in the database for every PlaceholderField on the model. But it fails if the model exists with multiple PlaceholderFields but only some of them have rows in the placeholder table.

This can happen in the following use case. Say you have a model like

    class Foo(models.Model):
        title = models.CharField(max_length=100)
        content_1 = PlaceholderField('content_1')

Then you create an instance of it in the Django admin. Afterwards you add another PlaceholderField to the model definition:

    class Foo(models.Model):
        title = models.CharField(max_length=100)
        content_1 = PlaceholderField('content_1')
        content_2 = PlaceholderField('content_2')

Now when `_construct_form(i=0)` is called we'll have:

    instance = self.get_queryset()[0]

and when `_construct_form(i=1)` is called we'll have

    values = self._initial[1]

The problem is that `self._initial` is:

    [{'slot': 'content_2'}, {'slot': 'content_1'}]

So the `content_1` slot gets chosen in both cases. The solution is to remove all the elements from `self._initial` that have corresponding elements in `self.get_queryset()` so we don't have any duplicates.