### PR TITLE
Make model strings explicitly unicode

### DIFF
--- a/fluent_contents/migrations/0001_initial.py
+++ b/fluent_contents/migrations/0001_initial.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('parent_id', models.IntegerField(null=True)),
-                ('language_code', models.CharField(default=b'', max_length=15, editable=False, db_index=True)),
+                ('language_code', models.CharField(default='', max_length=15, editable=False, db_index=True)),
                 ('sort_order', models.IntegerField(default=1, db_index=True)),
                 ('parent_type', models.ForeignKey(to='contenttypes.ContentType')),
             ],
@@ -33,7 +33,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('slot', models.SlugField(help_text='A short name to identify the placeholder in the template code.', verbose_name='Slot')),
-                ('role', models.CharField(default=b'm', help_text='This defines where the object is used.', max_length=1, verbose_name='Role', choices=[(b'm', 'Main content'), (b's', 'Sidebar content'), (b'r', 'Related content')])),
+                ('role', models.CharField(default='m', help_text='This defines where the object is used.', max_length=1, verbose_name='Role', choices=[('m', 'Main content'), ('s', 'Sidebar content'), ('r', 'Related content')])),
                 ('parent_id', models.IntegerField(null=True)),
                 ('title', models.CharField(max_length=255, verbose_name='Admin title', blank=True)),
                 ('parent_type', models.ForeignKey(blank=True, to='contenttypes.ContentType', null=True)),
@@ -51,13 +51,13 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='contentitem',
             name='placeholder',
-            field=models.ForeignKey(related_name=b'contentitems', on_delete=django.db.models.deletion.SET_NULL, to='fluent_contents.Placeholder', null=True),
+            field=models.ForeignKey(related_name='contentitems', on_delete=django.db.models.deletion.SET_NULL, to='fluent_contents.Placeholder', null=True),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='contentitem',
             name='polymorphic_ctype',
-            field=models.ForeignKey(related_name=b'polymorphic_fluent_contents.contentitem_set+', editable=False, to='contenttypes.ContentType', null=True),
+            field=models.ForeignKey(related_name='polymorphic_fluent_contents.contentitem_set+', editable=False, to='contenttypes.ContentType', null=True),
             preserve_default=True,
         ),
     ]

--- a/fluent_contents/models/db.py
+++ b/fluent_contents/models/db.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from copy import deepcopy
 from future.utils import with_metaclass, python_2_unicode_compatible, PY3
 from django.contrib.contenttypes.generic import GenericForeignKey


### PR DESCRIPTION
Currently some of the strings in the models will be either byte strings or unicode strings depending on whether you're using Python 2 or 3. This causes Django to create unnecessary migrations. This pull request fixes the issue.

See: https://docs.djangoproject.com/en/1.8/topics/migrations/#supporting-python-2-and-3

This supersedes https://github.com/edoburu/django-fluent-contents/pull/62